### PR TITLE
Use header tags instead of unordered list when "Render project names" enabled

### DIFF
--- a/src/formatTasks.ts
+++ b/src/formatTasks.ts
@@ -66,7 +66,7 @@ function renderTasksAsText(
     function renderTree(nodes: TodoistTask[], indent: number): string[] {
         return [...nodes].reverse().flatMap((t, idx) => {
             const tabs = settings.renderProjectsHeaders
-                ? "\t".repeat(indent + 1)
+                ? ""
                 : "\t".repeat(indent);
             const line = `${tabs}${renderTaskPrefix(t, idx)} ${
                 t.content
@@ -84,7 +84,7 @@ function renderTasksAsText(
         for (const [projId, meta] of Object.entries(projectsMetadata)) {
             const projTasks = tasks.filter((t) => t.projectId === projId);
             if (!projTasks.length) continue;
-            allLines.push(`* ${meta.name}`);
+            allLines.push(`##### ${meta.name}`);
             allLines.push(...renderTree(projTasks, 0));
         }
     } else {


### PR DESCRIPTION
Use `#####` instead of `*` when rendering project names

Fixes #31 

This is how it looks with this PR: 
<img width="708" height="283" alt="image" src="https://github.com/user-attachments/assets/3ed5feeb-7a7c-46d7-8a57-bd73e7e338fe" />
