### PR TITLE
Insert extra line break after all task list

### DIFF
--- a/src/formatTasks.ts
+++ b/src/formatTasks.ts
@@ -92,7 +92,7 @@ function renderTasksAsText(
     }
 
     if (allLines.length === 0) return "";
-    return `\n${allLines.join("\n")}\n`;
+    return `\n${allLines.join("\n")}\n\n`;
 }
 
 export { renderTasksAsText, prepareTasksForRendering };


### PR DESCRIPTION
This ensures the list renders correctly as it expects it to end with a blank line - and users often don't add it and end up with incorrectly rendered last part.

Fixes #40