### PR TITLE
Better support for non-UTC regions

### DIFF
--- a/src/fetchTasks.ts
+++ b/src/fetchTasks.ts
@@ -48,16 +48,17 @@ export async function fetchTasks(
     let mappedResults: any[] = [];
 
     try {
+        // Add 'Z' suffix to indicate UTC timezone for Todoist API
         const url =
             `https://api.todoist.com/sync/v9/completed/get_all?since=` +
             timeStartFormattedDate +
             `T` +
             timeStartFormattedTime +
-            `&until=` +
+            `Z&until=` +
             timeEndFormattedDate +
             `T` +
             timeEndFormattedTime +
-            `&limit=${limit}`;
+            `Z&limit=${limit}`;
         const completedTasksMetadata = await fetch(url, {
             headers: {
                 Authorization: `Bearer ${authToken}`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,17 +12,20 @@ function getTimeframesForUsersToday() {
         now.getMonth(),
         now.getDate()
     );
+    // Set end time to 23:59:59.999 to include all tasks completed before midnight
     const endLocal = new Date(
         now.getFullYear(),
         now.getMonth(),
         now.getDate(),
         23,
         59,
-        59
+        59,
+        999
     );
 
-    const mStart = moment(startLocal);
-    const mEnd = moment(endLocal);
+    // Convert local time to UTC for Todoist API (which stores times in UTC)
+    const mStart = moment(startLocal).utc();
+    const mEnd = moment(endLocal).utc();
 
     return {
         timeStartFormattedDate: mStart.format("YYYY-MM-DD"),
@@ -37,8 +40,9 @@ function getTimeframesForLastNHours(hours: number) {
     const startLocal = new Date(now.getTime() - hours * 60 * 60 * 1000);
     const endLocal = now;
 
-    const mStart = moment(startLocal);
-    const mEnd = moment(endLocal);
+    // Convert local time to UTC for Todoist API (which stores times in UTC)
+    const mStart = moment(startLocal).utc();
+    const mEnd = moment(endLocal).utc();
 
     return {
         timeStartFormattedDate: mStart.format("YYYY-MM-DD"),


### PR DESCRIPTION
This commit fixes timezone handling for users in non-UTC regions. Previously, the plugin used local time when querying the Todoist API, which stores completed task timestamps in UTC. This mismatch caused tasks completed near midnight (before 24:00) to be missed or incorrectly filtered.
The changes include:

- Converting local time to UTC before sending API requests using moment().utc()
- Adding the 'Z' suffix to time strings in API URLs to explicitly indicate UTC timezone
- Extending the end time to 23:59:59.999 to include all tasks completed before midnight

These updates ensure accurate task retrieval regardless of the user's timezone, resolving the issue where tasks completed late in the day were not being fetched correctly.